### PR TITLE
This commit fixes a bug where file uploads were failing due to an inc…

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -37,8 +37,11 @@ api.interceptors.request.use((config) => {
     config.headers.Authorization = `Bearer ${token}`;
   }
   
-  // Dodaj nagłówki dla CORS
-  config.headers['Content-Type'] = 'application/json';
+  // Ustaw Content-Type warunkowo. Nie ustawiaj dla FormData (upload plików).
+  if (!(config.data instanceof FormData)) {
+    config.headers['Content-Type'] = 'application/json';
+  }
+
   config.headers['Accept'] = 'application/json';
   
   return config;


### PR DESCRIPTION
…orrect `Content-Type` header.

The `axios` request interceptor in `frontend/src/services/api.js` was unconditionally setting the `Content-Type` to `application/json` for all requests. This prevented the browser from correctly setting the header to `multipart/form-data` for file uploads, causing the backend to reject the request.

The interceptor has been modified to conditionally set the `Content-Type` header, only applying it if the request data is not an instance of `FormData`. This allows file uploads to function correctly while preserving the header for standard JSON API calls.